### PR TITLE
feat: add devto-sync Taskfile tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules/
 
 # Superpowers brainstorm sessions
 .superpowers/
+
+# Built binaries
+bin/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,3 +96,61 @@ tasks:
       - echo "Site built successfully in public/"
     env:
       HUGO_ENV: production
+
+  devto:build:
+    desc: Build the devto-sync tool
+    dir: tools/devto-sync
+    cmds:
+      - go build -o ../../bin/devto-sync .
+    sources:
+      - "**/*.go"
+      - go.mod
+    generates:
+      - ../../bin/devto-sync
+
+  devto:push:
+    desc: Push posts to Dev.to (use SLUG=xxx for single post, or ALL=true for all)
+    deps: [devto:build]
+    cmds:
+      - |
+        args=""
+        {{ if .SLUG }}args="--slug {{.SLUG}}"{{ end }}
+        {{ if .ALL }}args="--all"{{ end }}
+        {{ if .DRY_RUN }}args="$args --dry-run"{{ end }}
+        ./bin/devto-sync push $args
+
+  devto:pull:
+    desc: Import from Dev.to (use ID=xxx or ALL=true with CATEGORY_MAP=file.csv)
+    deps: [devto:build]
+    cmds:
+      - |
+        args=""
+        {{ if .ID }}args="--id {{.ID}} --category {{.CATEGORY}}"{{ end }}
+        {{ if .ALL }}args="--all"{{ end }}
+        {{ if .CATEGORY_MAP }}args="$args --category-map {{.CATEGORY_MAP}}"{{ end }}
+        {{ if .DRY_RUN }}args="$args --dry-run"{{ end }}
+        ./bin/devto-sync pull $args
+
+  devto:status:
+    desc: Show sync state between blog and Dev.to
+    deps: [devto:build]
+    cmds:
+      - ./bin/devto-sync status
+
+  devto:triage:
+    desc: Propose archive/update/replace for imported posts
+    deps: [devto:build]
+    cmds:
+      - ./bin/devto-sync triage
+
+  devto:env:
+    desc: Export DEVTO_API_KEY from Ansible vault (run with 'eval $(task devto:env)')
+    cmds:
+      - echo "export DEVTO_API_KEY=$(ansible-vault decrypt --output - vault/devto-api-key.yml 2>/dev/null | grep api_key | cut -d' ' -f2)"
+    silent: true
+
+  devto:test:
+    desc: Run devto-sync tests
+    dir: tools/devto-sync
+    cmds:
+      - go test ./... -v

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -111,6 +111,9 @@ tasks:
   devto:push:
     desc: Push posts to Dev.to (use SLUG=xxx for single post, or ALL=true for all)
     deps: [devto:build]
+    preconditions:
+      - sh: '[ -n "{{.SLUG}}" ] || [ -n "{{.ALL}}" ]'
+        msg: "Usage: task devto:push SLUG=my-post  OR  task devto:push ALL=true"
     cmds:
       - |
         args=""
@@ -122,6 +125,9 @@ tasks:
   devto:pull:
     desc: Import from Dev.to (use ID=xxx or ALL=true with CATEGORY_MAP=file.csv)
     deps: [devto:build]
+    preconditions:
+      - sh: '[ -n "{{.ID}}" ] || [ -n "{{.ALL}}" ]'
+        msg: "Usage: task devto:pull ID=123 CATEGORY=go  OR  task devto:pull ALL=true CATEGORY_MAP=map.csv"
     cmds:
       - |
         args=""


### PR DESCRIPTION
## Summary
- Add 7 Taskfile tasks for the devto-sync tool: `devto:build`, `devto:push`, `devto:pull`, `devto:status`, `devto:triage`, `devto:env`, `devto:test`
- Add `bin/` to `.gitignore` for compiled Go binaries
- Implements Task 7 from the devto-sync implementation plan

## Test plan
- [x] `task --list | grep devto` shows all 7 tasks registered
- [ ] `task devto:build` compiles once `tools/devto-sync/` Go module exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)