### PR TITLE
docs: add devto-sync tool section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ task devto:push ALL=true       # Push all eligible posts
 task devto:pull ID=123 CATEGORY=go  # Import single article
 task devto:status              # Show sync state
 task devto:triage              # Propose archive/update/replace
+task devto:env                 # Export API key from vault for local use
 task devto:test                # Run tool tests
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,21 @@ task theme:update     # Pull latest PaperMod from master
 task deploy           # Clean + production build
 ```
 
+### Dev.to Sync Tool
+
+A Go CLI tool in `tools/devto-sync/` handles bidirectional sync with Dev.to. Blog is always canonical.
+
+```bash
+task devto:push SLUG=my-post   # Push single post
+task devto:push ALL=true       # Push all eligible posts
+task devto:pull ID=123 CATEGORY=go  # Import single article
+task devto:status              # Show sync state
+task devto:triage              # Propose archive/update/replace
+task devto:test                # Run tool tests
+```
+
+Posts opt in via `devto: true` in frontmatter (default in archetype). The `devto_id` field is written automatically after first push. Archived posts are excluded from sync.
+
 ## Configuration
 
 - `hugo.toml` — all Hugo and theme configuration (TOML format)


### PR DESCRIPTION
## Summary
- Add Dev.to Sync Tool subsection under Commands in CLAUDE.md
- Documents the six `task devto:*` commands and frontmatter opt-in conventions
- Part of Task 10 from the devto-sync implementation plan

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm section placement is consistent with existing CLAUDE.md structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)