### PR TITLE
feat(devto-sync): add --org-id flag to push command

### DIFF
--- a/tools/devto-sync/cmd/push.go
+++ b/tools/devto-sync/cmd/push.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/jonesrussell/blog/tools/devto-sync/internal/devto"
 	"github.com/jonesrussell/blog/tools/devto-sync/internal/hugo"
@@ -13,6 +14,7 @@ import (
 
 var pushAll bool
 var pushSlug string
+var orgID int
 
 var pushCmd = &cobra.Command{
 	Use:   "push",
@@ -26,6 +28,19 @@ var pushCmd = &cobra.Command{
 
 		client := devto.NewClient(apiKey)
 		engine := devsync.NewEngine(client, baseURL)
+
+		// Resolve org ID from flag or environment variable
+		oid := orgID
+		if oid == 0 {
+			if envVal := os.Getenv("DEVTO_ORG_ID"); envVal != "" {
+				parsed, err := strconv.Atoi(envVal)
+				if err != nil {
+					return fmt.Errorf("invalid DEVTO_ORG_ID=%q: %w", envVal, err)
+				}
+				oid = parsed
+			}
+		}
+		engine.OrgID = oid
 
 		posts, err := hugo.ListPosts(contentDir)
 		if err != nil {
@@ -97,5 +112,6 @@ var pushCmd = &cobra.Command{
 func init() {
 	pushCmd.Flags().BoolVar(&pushAll, "all", false, "Push all eligible posts")
 	pushCmd.Flags().StringVar(&pushSlug, "slug", "", "Push a specific post by slug")
+	pushCmd.Flags().IntVar(&orgID, "org-id", 0, "Dev.to organization ID to publish under")
 	rootCmd.AddCommand(pushCmd)
 }

--- a/tools/devto-sync/internal/devto/types.go
+++ b/tools/devto-sync/internal/devto/types.go
@@ -53,11 +53,12 @@ type ArticleCreate struct {
 
 // ArticleBody contains the fields for create/update.
 type ArticleBody struct {
-	Title        string   `json:"title"`
-	BodyMarkdown string   `json:"body_markdown"`
-	Published    bool     `json:"published"`
-	Tags         []string `json:"tags"`
-	Description  string   `json:"description,omitempty"`
-	CanonicalURL string   `json:"canonical_url,omitempty"`
-	Series       string   `json:"series,omitempty"`
+	Title          string   `json:"title"`
+	BodyMarkdown   string   `json:"body_markdown"`
+	Published      bool     `json:"published"`
+	Tags           []string `json:"tags"`
+	Description    string   `json:"description,omitempty"`
+	CanonicalURL   string   `json:"canonical_url,omitempty"`
+	Series         string   `json:"series,omitempty"`
+	OrganizationID int      `json:"organization_id,omitempty"`
 }

--- a/tools/devto-sync/internal/sync/engine.go
+++ b/tools/devto-sync/internal/sync/engine.go
@@ -15,6 +15,7 @@ import (
 type Engine struct {
 	client  *devto.Client
 	baseURL string
+	OrgID   int
 }
 
 // NewEngine creates a new sync engine.
@@ -64,7 +65,8 @@ func (e *Engine) PushPost(post *hugo.Post, dryRun bool) (*devto.Article, error) 
 			Tags:         tags,
 			Description:  post.Summary,
 			CanonicalURL: canonicalURL,
-			Series:       series,
+			Series:         series,
+			OrganizationID: e.OrgID,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Add `--org-id` flag to the `push` command so articles can be published under a Dev.to organization
- Support `DEVTO_ORG_ID` environment variable as fallback when flag is not provided
- Add `OrganizationID` field to `ArticleBody` (omitted from JSON when zero)

Closes #37

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `go build` — compiles successfully
- [x] `push --help` shows `--org-id` flag
- [x] `push --slug test --org-id 0 --dry-run` — flag accepted without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)