### PR TITLE
feat(devto-sync): add comments command (#35)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -150,6 +150,12 @@ tasks:
     cmds:
       - ./bin/devto-sync triage
 
+  devto:comments:
+    desc: Show unanswered comments across articles
+    deps: [devto:build]
+    cmds:
+      - ./bin/devto-sync comments
+
   devto:env:
     desc: Export DEVTO_API_KEY from Ansible vault (run with 'eval $(task devto:env)')
     cmds:

--- a/tools/devto-sync/cmd/comments.go
+++ b/tools/devto-sync/cmd/comments.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/jonesrussell/blog/tools/devto-sync/internal/devto"
+	"github.com/spf13/cobra"
+)
+
+var commentsCmd = &cobra.Command{
+	Use:   "comments",
+	Short: "Show unanswered comments across articles",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		apiKey := os.Getenv("DEVTO_API_KEY")
+		if apiKey == "" {
+			return fmt.Errorf("DEVTO_API_KEY environment variable is required")
+		}
+
+		client := devto.NewClient(apiKey)
+
+		articles, err := client.ListMyArticles()
+		if err != nil {
+			return fmt.Errorf("list articles: %w", err)
+		}
+
+		if len(articles) == 0 {
+			fmt.Println("No articles found.")
+			return nil
+		}
+
+		username := inferUsername(articles)
+
+		type unansweredComment struct {
+			articleTitle string
+			commenter   string
+			date        string
+			preview     string
+		}
+
+		var unanswered []unansweredComment
+
+		for _, article := range articles {
+			if !article.Published || article.CommentsCount == 0 {
+				continue
+			}
+
+			comments, err := client.ListComments(article.ID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not fetch comments for %q: %v\n", article.Title, err)
+				continue
+			}
+
+			for _, c := range findUnanswered(comments, username) {
+				unanswered = append(unanswered, unansweredComment{
+					articleTitle: truncate(article.Title, 40),
+					commenter:   c.User.Username,
+					date:        c.CreatedAt,
+					preview:     truncate(stripHTML(c.BodyHTML), 60),
+				})
+			}
+		}
+
+		if len(unanswered) == 0 {
+			fmt.Println("No unanswered comments.")
+			return nil
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ARTICLE\tCOMMENTER\tDATE\tPREVIEW")
+		fmt.Fprintln(w, "-------\t---------\t----\t-------")
+		for _, u := range unanswered {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", u.articleTitle, u.commenter, u.date, u.preview)
+		}
+		w.Flush()
+
+		fmt.Printf("\n%d unanswered comment(s)\n", len(unanswered))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(commentsCmd)
+}
+
+// inferUsername extracts the Dev.to username from the first article's URL.
+func inferUsername(articles []devto.Article) string {
+	for _, a := range articles {
+		// URL format: https://dev.to/username/slug
+		parts := strings.Split(strings.TrimPrefix(a.URL, "https://dev.to/"), "/")
+		if len(parts) >= 1 && parts[0] != "" {
+			return parts[0]
+		}
+	}
+	return ""
+}
+
+// findUnanswered returns top-level comments not by the author that have no
+// author reply in their children.
+func findUnanswered(comments []devto.Comment, username string) []devto.Comment {
+	var result []devto.Comment
+	for _, c := range comments {
+		if strings.EqualFold(c.User.Username, username) {
+			continue
+		}
+		if !hasReplyBy(c.Children, username) {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+func hasReplyBy(children []devto.Comment, username string) bool {
+	for _, child := range children {
+		if strings.EqualFold(child.User.Username, username) {
+			return true
+		}
+	}
+	return false
+}
+
+var htmlTagRe = regexp.MustCompile(`<[^>]*>`)
+
+// stripHTML removes HTML tags from a string.
+func stripHTML(s string) string {
+	return strings.TrimSpace(htmlTagRe.ReplaceAllString(s, ""))
+}
+

--- a/tools/devto-sync/internal/devto/client.go
+++ b/tools/devto-sync/internal/devto/client.go
@@ -125,6 +125,21 @@ func (c *Client) UpdateArticle(id int, req ArticleCreate) (*Article, error) {
 	return &article, nil
 }
 
+// ListComments returns all top-level comments for an article.
+func (c *Client) ListComments(articleID int) ([]Comment, error) {
+	c.readLimiter.wait()
+	url := fmt.Sprintf("%s/api/comments?a_id=%d", c.baseURL, articleID)
+	body, err := c.doRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list comments for article %d: %w", articleID, err)
+	}
+	var comments []Comment
+	if err := json.Unmarshal(body, &comments); err != nil {
+		return nil, fmt.Errorf("decode comments: %w", err)
+	}
+	return comments, nil
+}
+
 // DeleteArticle deletes an article by ID.
 func (c *Client) DeleteArticle(id int) error {
 	c.readLimiter.wait()

--- a/tools/devto-sync/internal/devto/types.go
+++ b/tools/devto-sync/internal/devto/types.go
@@ -42,12 +42,27 @@ type Article struct {
 	Slug         string   `json:"slug"`
 	BodyMarkdown string   `json:"body_markdown"`
 	Tags         FlexTags `json:"tag_list"`
-	Series       *string  `json:"series"`
-	PublishedAt             string   `json:"published_at"`
-	PageViewsCount         int      `json:"page_views_count"`
-	PositiveReactionsCount int      `json:"positive_reactions_count"`
-	PublicReactionsCount   int      `json:"public_reactions_count"`
-	CommentsCount          int      `json:"comments_count"`
+	Series                 *string  `json:"series"`
+	PublishedAt            string   `json:"published_at"`
+	PageViewsCount         int     `json:"page_views_count"`
+	PositiveReactionsCount int     `json:"positive_reactions_count"`
+	PublicReactionsCount   int     `json:"public_reactions_count"`
+	CommentsCount          int     `json:"comments_count"`
+}
+
+// Comment represents a Dev.to comment.
+type Comment struct {
+	IDCode    string      `json:"id_code"`
+	BodyHTML  string      `json:"body_html"`
+	User      CommentUser `json:"user"`
+	CreatedAt string      `json:"created_at"`
+	Children  []Comment   `json:"children"`
+}
+
+// CommentUser represents the author of a comment.
+type CommentUser struct {
+	Username string `json:"username"`
+	Name     string `json:"name"`
 }
 
 // ArticleCreate is the request body for creating/updating articles.


### PR DESCRIPTION
## Summary
- Adds `comments` subcommand to devto-sync CLI that shows unanswered Dev.to comments across all published articles
- Adds `Comment` and `CommentUser` types to `types.go`, `ListComments` method to `client.go`
- Adds `devto:comments` task to Taskfile.yml

## Test plan
- [x] `go build` compiles successfully
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `devto-sync comments --help` shows help text
- [ ] Manual: run `task devto:comments` with `DEVTO_API_KEY` set to verify output

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)