### PR TITLE
feat(devto-sync): add listings subcommand

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -168,6 +168,12 @@ tasks:
     cmds:
       - ./bin/devto-sync analytics {{.CLI_ARGS}}
 
+  devto:listings:
+    desc: Create a Dev.to listing
+    deps: [devto:build]
+    cmds:
+      - ./bin/devto-sync listings {{.CLI_ARGS}}
+
   devto:test:
     desc: Run devto-sync tests
     dir: tools/devto-sync

--- a/tools/devto-sync/cmd/listings.go
+++ b/tools/devto-sync/cmd/listings.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jonesrussell/blog/tools/devto-sync/internal/devto"
+	"github.com/spf13/cobra"
+)
+
+var (
+	listingTitle    string
+	listingBody     string
+	listingCategory string
+	listingTags     []string
+)
+
+var validCategories = map[string]bool{
+	"cfp":       true,
+	"forhire":   true,
+	"collabs":   true,
+	"education": true,
+	"jobs":      true,
+	"mentors":   true,
+	"mentees":   true,
+	"forsale":   true,
+	"events":    true,
+	"misc":      true,
+}
+
+var listingsCmd = &cobra.Command{
+	Use:   "listings",
+	Short: "Create a Dev.to listing",
+	Long:  "Create a classified listing on Dev.to (cfp, forhire, collabs, education, jobs, mentors, mentees, forsale, events, misc).",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if listingTitle == "" {
+			return fmt.Errorf("--title is required")
+		}
+		if listingBody == "" {
+			return fmt.Errorf("--body is required")
+		}
+		if listingCategory == "" {
+			return fmt.Errorf("--category is required")
+		}
+		if !validCategories[listingCategory] {
+			return fmt.Errorf("invalid category %q; valid: cfp, forhire, collabs, education, jobs, mentors, mentees, forsale, events, misc", listingCategory)
+		}
+
+		req := devto.ListingCreate{
+			Listing: devto.ListingBody{
+				Title:             listingTitle,
+				BodyMarkdown:      listingBody,
+				Category:          listingCategory,
+				Tags:              listingTags,
+				ContactViaConnect: true,
+			},
+		}
+
+		if dryRun {
+			fmt.Printf("[dry-run] Would create listing: title=%q category=%s\n", listingTitle, listingCategory)
+			return nil
+		}
+
+		apiKey := os.Getenv("DEVTO_API_KEY")
+		if apiKey == "" {
+			return fmt.Errorf("DEVTO_API_KEY environment variable is required")
+		}
+
+		client := devto.NewClient(apiKey)
+		listing, err := client.CreateListing(req)
+		if err != nil {
+			return fmt.Errorf("create listing: %w", err)
+		}
+
+		fmt.Printf("Created listing %d (category: %s)\n", listing.ID, listing.Category)
+		return nil
+	},
+}
+
+func init() {
+	listingsCmd.Flags().StringVar(&listingTitle, "title", "", "Listing title (required)")
+	listingsCmd.Flags().StringVar(&listingBody, "body", "", "Listing body in markdown (required)")
+	listingsCmd.Flags().StringVar(&listingCategory, "category", "", "Listing category (required): cfp, forhire, collabs, education, jobs, mentors, mentees, forsale, events, misc")
+	listingsCmd.Flags().StringSliceVar(&listingTags, "tags", nil, "Comma-separated tags")
+	rootCmd.AddCommand(listingsCmd)
+}

--- a/tools/devto-sync/internal/devto/client.go
+++ b/tools/devto-sync/internal/devto/client.go
@@ -148,6 +148,25 @@ func (c *Client) DeleteArticle(id int) error {
 	return err
 }
 
+// CreateListing creates a new Dev.to listing. Returns the created listing.
+func (c *Client) CreateListing(req ListingCreate) (*Listing, error) {
+	c.createLimiter.wait()
+	url := fmt.Sprintf("%s/api/listings", c.baseURL)
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode listing: %w", err)
+	}
+	body, err := c.doRequest("POST", url, payload)
+	if err != nil {
+		return nil, fmt.Errorf("create listing: %w", err)
+	}
+	var listing Listing
+	if err := json.Unmarshal(body, &listing); err != nil {
+		return nil, fmt.Errorf("decode listing: %w", err)
+	}
+	return &listing, nil
+}
+
 func (c *Client) doRequest(method, url string, payload []byte) ([]byte, error) {
 	return c.doRequestWithRetry(method, url, payload, 1)
 }

--- a/tools/devto-sync/internal/devto/types.go
+++ b/tools/devto-sync/internal/devto/types.go
@@ -70,6 +70,28 @@ type ArticleCreate struct {
 	Article ArticleBody `json:"article"`
 }
 
+// Listing represents a Dev.to listing (response).
+type Listing struct {
+	ID       int    `json:"id"`
+	Title    string `json:"title"`
+	Category string `json:"category"`
+	Slug     string `json:"slug"`
+}
+
+// ListingCreate is the request body for creating listings.
+type ListingCreate struct {
+	Listing ListingBody `json:"listing"`
+}
+
+// ListingBody contains the fields for listing create.
+type ListingBody struct {
+	Title             string   `json:"title"`
+	BodyMarkdown      string   `json:"body_markdown"`
+	Category          string   `json:"category"`
+	Tags              []string `json:"tags,omitempty"`
+	ContactViaConnect bool     `json:"contact_via_connect,omitempty"`
+}
+
 // ArticleBody contains the fields for create/update.
 type ArticleBody struct {
 	Title          string   `json:"title"`


### PR DESCRIPTION
## Summary
- Add `listings` subcommand to devto-sync CLI for creating Dev.to classified listings
- Add Listing, ListingCreate, ListingBody types and CreateListing client method
- Supports `--title`, `--body`, `--category`, `--tags` flags with category validation and `--dry-run`
- Add `devto:listings` task to Taskfile.yml

Closes #39

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `listings --help` shows all flags
- [x] `listings --title "test" --body "test" --category education --dry-run` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)