### PR TITLE
feat(devto-sync): add engage command

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -162,6 +162,7 @@ tasks:
       - echo "export DEVTO_API_KEY=$(ansible-vault decrypt --output - vault/devto-api-key.yml 2>/dev/null | grep api_key | cut -d' ' -f2)"
     silent: true
 
+<<<<<<< HEAD
   devto:analytics:
     desc: Show article performance stats
     deps: [devto:build]
@@ -185,6 +186,17 @@ tasks:
     deps: [devto:build]
     cmds:
       - ./bin/devto-sync followers
+
+  devto:engage:
+    desc: Like recent articles in tags you follow
+    deps: [devto:build]
+    cmds:
+      - |
+        args=""
+        {{ if .LIMIT }}args="$args --limit {{.LIMIT}}"{{ end }}
+        {{ if .DAYS }}args="$args --days {{.DAYS}}"{{ end }}
+        {{ if .DRY_RUN }}args="$args --dry-run"{{ end }}
+        ./bin/devto-sync engage $args
 
   devto:test:
     desc: Run devto-sync tests

--- a/tools/devto-sync/cmd/engage.go
+++ b/tools/devto-sync/cmd/engage.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jonesrussell/blog/tools/devto-sync/internal/devto"
+	"github.com/spf13/cobra"
+)
+
+var (
+	engageLimit int
+	engageDays  int
+)
+
+var engageCmd = &cobra.Command{
+	Use:   "engage",
+	Short: "Like recent articles in tags you follow",
+	Long:  "Fetches your followed tags, finds recent articles in each, and likes them to boost community engagement.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		apiKey := os.Getenv("DEVTO_API_KEY")
+		if apiKey == "" {
+			return fmt.Errorf("DEVTO_API_KEY environment variable is required")
+		}
+
+		client := devto.NewClient(apiKey)
+
+		// Fetch own article IDs to filter them out of engagement results.
+		myArticles, err := client.ListMyArticles()
+		if err != nil {
+			return fmt.Errorf("fetch own articles: %w", err)
+		}
+		myArticleIDs := make(map[int]bool, len(myArticles))
+		for _, a := range myArticles {
+			myArticleIDs[a.ID] = true
+		}
+
+		tags, err := client.ListFollowedTags()
+		if err != nil {
+			return fmt.Errorf("fetch followed tags: %w", err)
+		}
+		if len(tags) == 0 {
+			fmt.Println("You don't follow any tags on Dev.to.")
+			return nil
+		}
+
+		fmt.Printf("Found %d followed tags, looking back %d days (limit: %d likes)\n\n", len(tags), engageDays, engageLimit)
+
+		liked := 0
+		seen := make(map[int]bool)
+
+		for _, tag := range tags {
+			if liked >= engageLimit {
+				break
+			}
+
+			articles, err := client.ListArticlesByTag(tag.Name, engageDays)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to fetch articles for tag %q: %v\n", tag.Name, err)
+				continue
+			}
+
+			for _, article := range articles {
+				if liked >= engageLimit {
+					break
+				}
+				// Skip own articles and already-seen articles.
+				if myArticleIDs[article.ID] || seen[article.ID] {
+					continue
+				}
+				seen[article.ID] = true
+
+				if dryRun {
+					fmt.Printf("[dry-run] Would like: %q by @%s (%s)\n", article.Title, article.User.Username, article.URL)
+					liked++
+					continue
+				}
+
+				result, err := client.ToggleReaction(devto.ReactionToggle{
+					Category:      "like",
+					ReactableID:   article.ID,
+					ReactableType: "Article",
+				})
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to like article %d: %v\n", article.ID, err)
+					continue
+				}
+
+				if result.Result == "created" {
+					fmt.Printf("Liked: %q by @%s (%s)\n", article.Title, article.User.Username, article.URL)
+					liked++
+				}
+				// If result is "unchanged", the article was already liked — skip silently.
+			}
+		}
+
+		fmt.Printf("\nDone: %d articles liked\n", liked)
+		return nil
+	},
+}
+
+func init() {
+	engageCmd.Flags().IntVar(&engageLimit, "limit", 10, "Maximum number of articles to like")
+	engageCmd.Flags().IntVar(&engageDays, "days", 7, "Look back N days for articles")
+	rootCmd.AddCommand(engageCmd)
+}

--- a/tools/devto-sync/internal/devto/client.go
+++ b/tools/devto-sync/internal/devto/client.go
@@ -197,6 +197,55 @@ func (c *Client) ListTags(page, perPage int) ([]Tag, error) {
 	return tags, nil
 }
 
+// ToggleReaction toggles a reaction (like/unicorn/readinglist) on a reactable.
+func (c *Client) ToggleReaction(req ReactionToggle) (*ReactionResult, error) {
+	c.createLimiter.wait()
+	url := fmt.Sprintf("%s/api/reactions", c.baseURL)
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode reaction: %w", err)
+	}
+	body, err := c.doRequest("POST", url, payload)
+	if err != nil {
+		return nil, fmt.Errorf("toggle reaction: %w", err)
+	}
+	var result ReactionResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode reaction result: %w", err)
+	}
+	return &result, nil
+}
+
+// ListFollowedTags returns tags the authenticated user follows.
+func (c *Client) ListFollowedTags() ([]FollowedTag, error) {
+	c.readLimiter.wait()
+	url := fmt.Sprintf("%s/api/follows/tags", c.baseURL)
+	body, err := c.doRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list followed tags: %w", err)
+	}
+	var tags []FollowedTag
+	if err := json.Unmarshal(body, &tags); err != nil {
+		return nil, fmt.Errorf("decode followed tags: %w", err)
+	}
+	return tags, nil
+}
+
+// ListArticlesByTag returns recent articles for a given tag.
+// The top parameter specifies the time window in days.
+func (c *Client) ListArticlesByTag(tag string, top int) ([]ArticleByTag, error) {
+	c.readLimiter.wait()
+	url := fmt.Sprintf("%s/api/articles?tag=%s&top=%d&per_page=10", c.baseURL, tag, top)
+	body, err := c.doRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list articles by tag %q: %w", tag, err)
+	}
+	var articles []ArticleByTag
+	if err := json.Unmarshal(body, &articles); err != nil {
+		return nil, fmt.Errorf("decode articles by tag: %w", err)
+	}
+	return articles, nil
+}
 func (c *Client) doRequest(method, url string, payload []byte) ([]byte, error) {
 	return c.doRequestWithRetry(method, url, payload, 1)
 }

--- a/tools/devto-sync/internal/devto/types.go
+++ b/tools/devto-sync/internal/devto/types.go
@@ -83,6 +83,43 @@ type Follower struct {
 	ProfileImage string `json:"profile_image"`
 }
 
+// ArticleUser represents a user in article responses.
+type ArticleUser struct {
+	Username string `json:"username"`
+	Name     string `json:"name"`
+}
+
+// ReactionToggle is the request body for toggling a reaction.
+type ReactionToggle struct {
+	Category      string `json:"category"`
+	ReactableID   int    `json:"reactable_id"`
+	ReactableType string `json:"reactable_type"`
+}
+
+// ReactionResult is the response from toggling a reaction.
+type ReactionResult struct {
+	Result   string `json:"result"`
+	Category string `json:"category"`
+	ID       int    `json:"id"`
+}
+
+// FollowedTag represents a tag the authenticated user follows.
+type FollowedTag struct {
+	ID     int     `json:"id"`
+	Name   string  `json:"name"`
+	Points float64 `json:"points"`
+}
+
+// ArticleByTag represents an article returned by the tag-based listing endpoint.
+type ArticleByTag struct {
+	ID              int         `json:"id"`
+	Title           string      `json:"title"`
+	URL             string      `json:"url"`
+	User            ArticleUser `json:"user"`
+	PublicReactions int         `json:"public_reactions_count"`
+	PublishedAt     string      `json:"published_at"`
+}
+
 // ArticleCreate is the request body for creating/updating articles.
 type ArticleCreate struct {
 	Article ArticleBody `json:"article"`


### PR DESCRIPTION
## Summary
- Adds `engage` subcommand to the devto-sync CLI that likes recent articles in tags you follow on Dev.to
- New types (`ReactionToggle`, `ReactionResult`, `FollowedTag`, `ArticleByTag`) and client methods (`ToggleReaction`, `ListFollowedTags`, `ListArticlesByTag`)
- Supports `--limit`, `--days`, and `--dry-run` flags; filters out own articles and deduplicates across tags

## Test plan
- [x] `go build` compiles successfully
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing tests green)
- [x] `devto-sync engage --help` shows expected flags (--limit, --days)
- [ ] Manual: `task devto:engage DRY_RUN=true` with DEVTO_API_KEY set

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)