### PR TITLE
feat(devto-sync): add followers subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ node_modules/
 # Built binaries
 bin/
 .task/
+
+# Dev.to sync local data
+tools/devto-sync/data/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -180,6 +180,12 @@ tasks:
     cmds:
       - ./bin/devto-sync tags
 
+  devto:followers:
+    desc: Track follower count and growth
+    deps: [devto:build]
+    cmds:
+      - ./bin/devto-sync followers
+
   devto:test:
     desc: Run devto-sync tests
     dir: tools/devto-sync

--- a/tools/devto-sync/cmd/followers.go
+++ b/tools/devto-sync/cmd/followers.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jonesrussell/blog/tools/devto-sync/internal/devto"
+	"github.com/spf13/cobra"
+)
+
+const (
+	followersPerPage = 1000
+	maxSnapshots     = 52
+)
+
+type followerSnapshot struct {
+	Count     int      `json:"count"`
+	Timestamp string   `json:"timestamp"`
+	Usernames []string `json:"usernames,omitempty"`
+}
+
+type followerHistory struct {
+	Snapshots []followerSnapshot `json:"snapshots"`
+}
+
+var followersCmd = &cobra.Command{
+	Use:   "followers",
+	Short: "Track follower count and growth over time",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		apiKey := os.Getenv("DEVTO_API_KEY")
+		if apiKey == "" {
+			return fmt.Errorf("DEVTO_API_KEY environment variable is required")
+		}
+
+		client := devto.NewClient(apiKey)
+
+		var allFollowers []devto.Follower
+		page := 1
+		for {
+			followers, err := client.ListFollowers(page, followersPerPage)
+			if err != nil {
+				return fmt.Errorf("fetch followers: %w", err)
+			}
+			if len(followers) == 0 {
+				break
+			}
+			allFollowers = append(allFollowers, followers...)
+			if len(followers) < followersPerPage {
+				break
+			}
+			page++
+		}
+
+		currentCount := len(allFollowers)
+		currentUsernames := make([]string, len(allFollowers))
+		for i, f := range allFollowers {
+			currentUsernames[i] = f.Username
+		}
+
+		dataDir := filepath.Join("tools", "devto-sync", "data")
+		historyPath := filepath.Join(dataDir, "followers.json")
+
+		history := followerHistory{}
+		if data, err := os.ReadFile(historyPath); err == nil {
+			if err := json.Unmarshal(data, &history); err != nil {
+				return fmt.Errorf("decode history: %w", err)
+			}
+		}
+
+		fmt.Printf("Current followers: %d\n", currentCount)
+
+		if len(history.Snapshots) > 0 {
+			last := history.Snapshots[len(history.Snapshots)-1]
+			diff := currentCount - last.Count
+			switch {
+			case diff > 0:
+				fmt.Printf("Change: +%d since %s\n", diff, last.Timestamp)
+			case diff < 0:
+				fmt.Printf("Change: %d since %s\n", diff, last.Timestamp)
+			default:
+				fmt.Printf("Change: no change since %s\n", last.Timestamp)
+			}
+
+			if diff > 0 && diff <= 20 {
+				lastSet := make(map[string]bool, len(last.Usernames))
+				for _, u := range last.Usernames {
+					lastSet[u] = true
+				}
+				fmt.Println("New followers:")
+				for _, u := range currentUsernames {
+					if !lastSet[u] {
+						fmt.Printf("  - @%s\n", u)
+					}
+				}
+			}
+		}
+
+		snapshot := followerSnapshot{
+			Count:     currentCount,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Usernames: currentUsernames,
+		}
+		history.Snapshots = append(history.Snapshots, snapshot)
+
+		if len(history.Snapshots) > maxSnapshots {
+			history.Snapshots = history.Snapshots[len(history.Snapshots)-maxSnapshots:]
+		}
+
+		if err := os.MkdirAll(dataDir, 0o755); err != nil {
+			return fmt.Errorf("create data dir: %w", err)
+		}
+
+		data, err := json.MarshalIndent(history, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encode history: %w", err)
+		}
+		if err := os.WriteFile(historyPath, data, 0o644); err != nil {
+			return fmt.Errorf("write history: %w", err)
+		}
+
+		fmt.Printf("Snapshot saved to %s\n", historyPath)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(followersCmd)
+}

--- a/tools/devto-sync/internal/devto/client.go
+++ b/tools/devto-sync/internal/devto/client.go
@@ -140,6 +140,21 @@ func (c *Client) ListComments(articleID int) ([]Comment, error) {
 	return comments, nil
 }
 
+// ListFollowers returns a page of followers for the authenticated user.
+func (c *Client) ListFollowers(page, perPage int) ([]Follower, error) {
+	c.readLimiter.wait()
+	url := fmt.Sprintf("%s/api/followers/users?page=%d&per_page=%d&sort=-created_at", c.baseURL, page, perPage)
+	body, err := c.doRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list followers page %d: %w", page, err)
+	}
+	var followers []Follower
+	if err := json.Unmarshal(body, &followers); err != nil {
+		return nil, fmt.Errorf("decode followers: %w", err)
+	}
+	return followers, nil
+}
+
 // DeleteArticle deletes an article by ID.
 func (c *Client) DeleteArticle(id int) error {
 	c.readLimiter.wait()

--- a/tools/devto-sync/internal/devto/types.go
+++ b/tools/devto-sync/internal/devto/types.go
@@ -73,6 +73,16 @@ type Tag struct {
 	TextColor string `json:"text_color_hex"`
 }
 
+// Follower represents a Dev.to follower.
+type Follower struct {
+	ID           int    `json:"id"`
+	UserID       int    `json:"user_id"`
+	Name         string `json:"name"`
+	Username     string `json:"username"`
+	CreatedAt    string `json:"created_at"`
+	ProfileImage string `json:"profile_image"`
+}
+
 // ArticleCreate is the request body for creating/updating articles.
 type ArticleCreate struct {
 	Article ArticleBody `json:"article"`


### PR DESCRIPTION
## Summary
- Adds `Follower` type and `ListFollowers` paginated API method to the devto client
- Creates `followers` Cobra subcommand that fetches all followers, compares with last snapshot, reports growth (+N/-N/no change) and lists new usernames when diff <= 20
- Persists history to `tools/devto-sync/data/followers.json` (max 52 snapshots, gitignored)
- Adds `devto:followers` task to Taskfile.yml

Closes #36

## Test plan
- [x] `go build` compiles successfully
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (existing tests unaffected)
- [x] `devto-sync followers --help` shows usage
- [ ] Run `devto-sync followers` with `DEVTO_API_KEY` set to verify live API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)