### PR TITLE
feat(devto-sync): add tags command (#40)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -174,6 +174,12 @@ tasks:
     cmds:
       - ./bin/devto-sync listings {{.CLI_ARGS}}
 
+  devto:tags:
+    desc: Check tags against Dev.to registry
+    deps: [devto:build]
+    cmds:
+      - ./bin/devto-sync tags
+
   devto:test:
     desc: Run devto-sync tests
     dir: tools/devto-sync

--- a/tools/devto-sync/cmd/tags.go
+++ b/tools/devto-sync/cmd/tags.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/jonesrussell/blog/tools/devto-sync/internal/devto"
+	"github.com/jonesrussell/blog/tools/devto-sync/internal/hugo"
+	"github.com/spf13/cobra"
+)
+
+var tagsCmd = &cobra.Command{
+	Use:   "tags",
+	Short: "Check post tags against the Dev.to tag registry",
+	Long:  "Fetches the top 500 tags from Dev.to and checks each syncable post's tags against them.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		apiKey := os.Getenv("DEVTO_API_KEY")
+		if apiKey == "" {
+			return fmt.Errorf("DEVTO_API_KEY environment variable is required")
+		}
+
+		client := devto.NewClient(apiKey)
+
+		// Fetch top 500 tags (5 pages x 100)
+		known := make(map[string]bool)
+		for page := 1; page <= 5; page++ {
+			tags, err := client.ListTags(page, 100)
+			if err != nil {
+				return fmt.Errorf("fetch tags page %d: %w", page, err)
+			}
+			for _, t := range tags {
+				known[strings.ToLower(t.Name)] = true
+			}
+			if len(tags) < 100 {
+				break
+			}
+		}
+		fmt.Fprintf(os.Stderr, "Loaded %d known Dev.to tags\n", len(known))
+
+		posts, err := hugo.ListPosts(contentDir)
+		if err != nil {
+			return fmt.Errorf("list posts: %w", err)
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "POST\tTAG\tSTATUS")
+		fmt.Fprintln(w, "----\t---\t------")
+
+		issues := 0
+		for _, p := range posts {
+			if !p.ShouldSync() {
+				continue
+			}
+			for _, tag := range p.Tags {
+				sanitized := strings.ToLower(strings.ReplaceAll(tag, "-", ""))
+				if !known[sanitized] {
+					fmt.Fprintf(w, "%s\t%s\tNOT FOUND on Dev.to\n", truncateStr(p.Slug, 40), tag)
+					issues++
+				}
+			}
+		}
+		w.Flush()
+
+		if issues == 0 {
+			fmt.Println("All tags recognized on Dev.to.")
+		} else {
+			fmt.Printf("\n%d tag(s) not found in Dev.to's top 500 tags.\n", issues)
+		}
+		return nil
+	},
+}
+
+func truncateStr(s string, max int) string {
+	if max < 4 {
+		max = 4
+	}
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}
+
+func init() {
+	rootCmd.AddCommand(tagsCmd)
+}

--- a/tools/devto-sync/internal/devto/client.go
+++ b/tools/devto-sync/internal/devto/client.go
@@ -167,6 +167,21 @@ func (c *Client) CreateListing(req ListingCreate) (*Listing, error) {
 	return &listing, nil
 }
 
+// ListTags returns tags from the Dev.to public tag registry.
+func (c *Client) ListTags(page, perPage int) ([]Tag, error) {
+	c.readLimiter.wait()
+	url := fmt.Sprintf("%s/api/tags?page=%d&per_page=%d", c.baseURL, page, perPage)
+	body, err := c.doRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list tags page %d: %w", page, err)
+	}
+	var tags []Tag
+	if err := json.Unmarshal(body, &tags); err != nil {
+		return nil, fmt.Errorf("decode tags: %w", err)
+	}
+	return tags, nil
+}
+
 func (c *Client) doRequest(method, url string, payload []byte) ([]byte, error) {
 	return c.doRequestWithRetry(method, url, payload, 1)
 }

--- a/tools/devto-sync/internal/devto/types.go
+++ b/tools/devto-sync/internal/devto/types.go
@@ -65,6 +65,14 @@ type CommentUser struct {
 	Name     string `json:"name"`
 }
 
+// Tag represents a Dev.to tag from the public tag registry.
+type Tag struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	BGColor   string `json:"bg_color_hex"`
+	TextColor string `json:"text_color_hex"`
+}
+
 // ArticleCreate is the request body for creating/updating articles.
 type ArticleCreate struct {
 	Article ArticleBody `json:"article"`


### PR DESCRIPTION
## Summary
- Adds `tags` subcommand to devto-sync CLI that fetches top 500 Dev.to tags and validates each syncable post's tags against them
- Adds `Tag` type to `internal/devto/types.go` and `ListTags` client method to `internal/devto/client.go`
- Adds `devto:tags` task to `Taskfile.yml`

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `go build` — compiles successfully
- [x] `devto-sync tags --help` — shows expected help text

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)