### PR TITLE
chore: generate OG images automatically in deploy workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -47,6 +47,21 @@ jobs:
         with:
           enablement: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      - name: Generate OG images
+        run: node scripts/generate-og-images.js
+
       - name: Build with Hugo
         run: |
           hugo \


### PR DESCRIPTION
## Summary
- Adds Node.js, npm ci, and Playwright Chromium setup to the Hugo deploy workflow
- Runs `node scripts/generate-og-images.js` before `hugo build` so any missing OG images are generated automatically
- Incremental: only generates images that don't already exist (unless template changed)

## Test plan
- [ ] Workflow completes without error
- [ ] OG images appear in deployed site for new posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)