### PR TITLE
social planning: April 2026 ramp

### DIFF
--- a/docs/social/available-for-hire.md
+++ b/docs/social/available-for-hire.md
@@ -1,0 +1,21 @@
+# Available for hire
+
+## Facebook
+
+Updated my GitHub profile with an available for hire section and a lead tracking template. If you are looking for a Go or PHP developer with experience building frameworks, APIs, and AI-integrated systems, I am open to conversations.
+
+https://github.com/jonesrussell/jonesrussell/commit/2e62dbc
+
+#hiring #go #php
+
+## X
+
+Available for hire. Go, PHP, framework dev, AI integration. Updated my profile with details. https://github.com/jonesrussell/jonesrussell/commit/2e62dbc #buildinpublic
+
+## LinkedIn
+
+I have updated my GitHub profile to reflect that I am available for new work. My background is in Go and PHP, with recent focus on framework development (Waaseyaa), AI-integrated systems, and open source tooling.
+
+If you are building something in that space and want to talk, reach out directly or check the profile for context.
+
+https://github.com/jonesrussell/jonesrussell/commit/2e62dbc

--- a/docs/social/giiken-frontend-stack.md
+++ b/docs/social/giiken-frontend-stack.md
@@ -1,0 +1,23 @@
+# Giiken frontend: Vue 3, Vite, Tailwind, Inertia
+
+## Facebook
+
+Scaffolded the Giiken frontend: Vue 3, Vite, Tailwind CSS, and Inertia.js. Standard stack for a Waaseyaa application — the same combination used across the other apps in the ecosystem.
+
+Giiken is a community knowledge management system. The frontend provides the discovery interface where community members search, ask questions, and explore linked documents. Getting the scaffold right means not having to undo decisions later.
+
+https://github.com/waaseyaa/giiken/commit/3895eca
+
+#vue #inertia #buildinpublic
+
+## X
+
+Giiken frontend scaffolded: Vue 3, Vite, Tailwind, Inertia. Discovery interface for community knowledge management, built on Waaseyaa. https://github.com/waaseyaa/giiken/commit/3895eca #buildinpublic
+
+## LinkedIn
+
+Scaffolded the frontend for Giiken, a community knowledge management system built on the Waaseyaa framework. Stack: Vue 3, Vite, Tailwind CSS, and Inertia.js — the same combination used across the Waaseyaa application ecosystem.
+
+The frontend provides the discovery layer: search, semantic Q&A, and document exploration for community members. Using Inertia means keeping the routing and auth in PHP while building the UI in Vue, which fits the Waaseyaa architecture well.
+
+https://github.com/waaseyaa/giiken/commit/3895eca

--- a/docs/social/giiken-product-intro.md
+++ b/docs/social/giiken-product-intro.md
@@ -1,0 +1,25 @@
+# Giiken: community knowledge management on Waaseyaa
+
+## Facebook
+
+Giiken is a community knowledge management system built on the Waaseyaa PHP framework. Here is what has shipped so far: application scaffold, Community and KnowledgeItem entity types, community RBAC policies, a document ingestion pipeline with link and embedding steps, a wiki schema with a lint system, and a query layer with full-text and semantic search.
+
+The MVP acceptance scenario is a real one: a community weighing the Massey Solar project uses Giiken to ingest meeting documents, link related items, and query the knowledge base for prior discussion. The system can surface relevant context that would otherwise be buried in a folder of PDFs.
+
+https://github.com/waaseyaa/giiken
+
+#php #ai #buildinpublic
+
+## X
+
+Giiken MVP: community knowledge management on Waaseyaa. Ingestion pipeline, wiki schema, semantic search, RBAC. Acceptance scenario: the Massey Solar community debate. https://github.com/waaseyaa/giiken #buildinpublic
+
+## LinkedIn
+
+Giiken is a community knowledge management system built on the Waaseyaa PHP framework. The goal is to give communities a way to ingest, link, and query their own documents — meeting records, reports, prior decisions — so that institutional knowledge is searchable rather than buried.
+
+What has shipped: entity types (Community, KnowledgeItem), RBAC policies, a document ingestion pipeline with link and embedding compilation steps, a wiki schema with automated lint checks, and a query layer supporting full-text and semantic search.
+
+The MVP acceptance scenario is grounded in a real case: a community evaluating a solar project uses Giiken to compile and query relevant documents and prior discussion. If the system can surface that context on demand, it works.
+
+https://github.com/waaseyaa/giiken

--- a/docs/social/symfony-floor-constraints.md
+++ b/docs/social/symfony-floor-constraints.md
@@ -1,0 +1,23 @@
+# Symfony ^7.3 floor constraints audit
+
+## Facebook
+
+Audited Symfony version floors across the Waaseyaa framework monorepo. Found 6 packages pinned to ^7.3. Checked each one against its actual Symfony API usage. None of them called anything that requires 7.3. All 6 relaxed to ^7.0.
+
+The policy going forward: every floor constraint needs a named API reason to exist, or it gets relaxed. Undocumented floors are a silent compatibility tax on every downstream consumer.
+
+https://github.com/waaseyaa/framework/issues/1151
+
+#php #symfony #opensource
+
+## X
+
+Audited 6 Symfony ^7.3 floors in our monorepo. None were justified by actual API usage. All 6 relaxed to ^7.0. Policy: every floor needs a named reason or it goes. https://github.com/waaseyaa/framework/issues/1151 #buildinpublic
+
+## LinkedIn
+
+Audited Symfony version floor constraints across the Waaseyaa framework monorepo. Six packages were pinned to ^7.3. After checking each against actual API usage, none of them required anything introduced after 7.0. All six were relaxed.
+
+The new policy: every ^7.x floor constraint must be documented with the specific API or behavior that requires it. If you can't name the reason, you relax it. Undocumented floors silently restrict downstream consumers.
+
+https://github.com/waaseyaa/framework/issues/1151

--- a/docs/social/waaseyaa-boot-to-browser.md
+++ b/docs/social/waaseyaa-boot-to-browser.md
@@ -1,0 +1,23 @@
+# Waaseyaa boot-to-browser DX: 4 framework fixes
+
+## Facebook
+
+Shipped 4 framework fixes targeting the boot-to-browser experience in Waaseyaa: the gap between cloning a repo and having something running in your browser. Each fix removed a step that required manual intervention or produced a confusing error.
+
+This kind of DX work is unsexy but important. A framework that is hard to stand up locally does not get adopted, regardless of what it can do once running.
+
+https://github.com/waaseyaa/framework/issues/1125
+
+#php #dx #waaseyaa
+
+## X
+
+4 Waaseyaa framework fixes targeting the gap between clone and running browser. Boot-to-browser DX matters for adoption. https://github.com/waaseyaa/framework/issues/1125 #buildinpublic
+
+## LinkedIn
+
+Shipped 4 framework-level fixes to the Waaseyaa boot-to-browser experience: the distance between cloning a repository and having the application running in a browser with no manual intervention.
+
+Each fix removed something that required extra steps, produced an unhelpful error, or assumed setup that was not documented. Developer experience at the start of a project shapes whether anyone gets far enough to see what the framework actually does.
+
+https://github.com/waaseyaa/framework/issues/1125

--- a/docs/social/waaseyaa-conformance-governance.md
+++ b/docs/social/waaseyaa-conformance-governance.md
@@ -1,0 +1,25 @@
+# Waaseyaa M11: conformance governance protocols
+
+## Facebook
+
+In an AI-assisted codebase, architectural drift is the default. Each session adds something slightly off-spec. Over time the deviations compound and the architecture you intended is no longer the one you have.
+
+Shipped four governance protocols for the Waaseyaa framework as part of the M11 milestone: a post-execution bootstrap that confirms conformance after each governed change, a canonical governed-change template, a periodic drift-scan for detecting C17+ deviations, and a steady-state conformance loop. Every change goes through the template. The drift scan runs on a schedule. Deviations surface before they compound.
+
+https://github.com/waaseyaa/framework/issues/998
+
+#ai #architecture #buildinpublic
+
+## X
+
+AI-assisted codebases drift by default. Shipped 4 Waaseyaa governance protocols: governed-change template, drift scan, conformance loop, bootstrap. Catch deviations before they compound. https://github.com/waaseyaa/framework/issues/998 #buildinpublic
+
+## LinkedIn
+
+Architectural drift is the default outcome in AI-assisted development. Each session produces something slightly off-spec. Without a systematic check, those deviations accumulate until the codebase no longer reflects the intended architecture.
+
+As part of the Waaseyaa M11 milestone, I shipped four conformance governance protocols: a post-execution bootstrap that confirms architectural conformance after each governed change, a canonical template for governed changes, a periodic drift-scan protocol for detecting deviations at C17 severity and above, and a steady-state conformance loop.
+
+The approach: make governed changes the path of least resistance, make drift visible on a schedule, and catch compounding issues before they require a large remediation effort.
+
+https://github.com/waaseyaa/framework/issues/998

--- a/docs/social/waaseyaa-null-llm-provider.md
+++ b/docs/social/waaseyaa-null-llm-provider.md
@@ -1,0 +1,23 @@
+# Waaseyaa NullLlmProvider for dev and testing
+
+## Facebook
+
+Added a NullLlmProvider to the Waaseyaa AI agent package. It satisfies the LlmProvider interface but does nothing — returns empty responses, logs calls, costs nothing to run.
+
+The point: you should not need a live LLM to run your test suite or spin up a dev environment. Real API calls in tests are slow, flaky, and expensive. The null provider lets you test all the wiring without touching an external service.
+
+https://github.com/waaseyaa/framework/issues/1122
+
+#php #testing #ai
+
+## X
+
+Added NullLlmProvider to Waaseyaa. Satisfies the interface, returns nothing, costs nothing. You should not need a live LLM to run your tests. https://github.com/waaseyaa/framework/issues/1122 #buildinpublic
+
+## LinkedIn
+
+Added a NullLlmProvider to the Waaseyaa framework's AI agent package. It satisfies the LlmProvider interface and returns empty responses — useful for development and testing scenarios where you want to verify the wiring without making real API calls.
+
+The principle is the same as a null mailer or a null payment gateway: your tests should be able to exercise the full stack without depending on external services. Fast, free, and deterministic.
+
+https://github.com/waaseyaa/framework/issues/1122

--- a/docs/social/waaseyaa-nuxt4-upgrade.md
+++ b/docs/social/waaseyaa-nuxt4-upgrade.md
@@ -1,0 +1,23 @@
+# Waaseyaa admin panel: Nuxt 4 upgrade
+
+## Facebook
+
+Upgraded the Waaseyaa admin panel from Nuxt 3 to Nuxt 4. Fixed the proxy architecture while in there, cleaned up the plugin setup. These upgrade sessions are good for catching things that accumulated since the last major bump.
+
+The admin panel is the internal interface for managing a Waaseyaa application — entity types, permissions, content. Keeping it on current Nuxt means staying on the right side of the Vue ecosystem.
+
+https://github.com/waaseyaa/framework/commit/f60a431
+
+#nuxt #vue #waaseyaa
+
+## X
+
+Upgraded the Waaseyaa admin panel to Nuxt 4. Fixed proxy architecture, cleaned up plugins while in there. https://github.com/waaseyaa/framework/commit/f60a431 #buildinpublic
+
+## LinkedIn
+
+Upgraded the Waaseyaa framework's admin panel to Nuxt 4. Along the way, fixed an issue with the proxy architecture and cleaned up the plugin configuration that had accumulated debt since the last major version.
+
+Framework maintenance work like this is not glamorous, but staying current on Nuxt means staying current on Vue 3 patterns, composition API improvements, and the surrounding tooling ecosystem.
+
+https://github.com/waaseyaa/framework/commit/f60a431

--- a/docs/social/waaseyaa-sqlite-dev-mode.md
+++ b/docs/social/waaseyaa-sqlite-dev-mode.md
@@ -1,0 +1,23 @@
+# Waaseyaa serve command: auto-create SQLite in dev mode
+
+## Facebook
+
+Small but useful: the Waaseyaa serve command now auto-creates the SQLite database when running in development mode. One less thing to do when standing up a new app or cloning a fresh repo.
+
+It is the kind of DX friction that adds up — you run the server, it fails, you go find the setup docs, you run a migration manually. Now it just works.
+
+https://github.com/waaseyaa/framework/issues/1116
+
+#php #waaseyaa #dx
+
+## X
+
+Waaseyaa serve command now auto-creates the SQLite database in dev mode. Clone, serve, done. https://github.com/waaseyaa/framework/issues/1116 #buildinpublic
+
+## LinkedIn
+
+A small DX improvement to the Waaseyaa framework: the serve command now automatically creates the SQLite database when running in development mode.
+
+It removes the step where a new developer clones the repo, runs the server, hits a database-not-found error, and has to find the setup instructions. The first run just works.
+
+https://github.com/waaseyaa/framework/issues/1116

--- a/docs/social/waaseyaa-strategy-pattern-dispatch.md
+++ b/docs/social/waaseyaa-strategy-pattern-dispatch.md
@@ -1,0 +1,23 @@
+# Waaseyaa API layer: strategy pattern replaces instanceof dispatch
+
+## Facebook
+
+Replaced a chain of instanceof checks in the Waaseyaa API layer with a strategy pattern. The old code had to know about every concrete type to decide how to handle a request. The new code delegates to the right handler without that knowledge.
+
+The instanceof chain was readable at first. It became a problem every time a new request type was added — you had to touch the dispatch logic, which should not change when you add new types. The strategy pattern fixes that.
+
+https://github.com/waaseyaa/framework/issues/1111
+
+#php #refactoring #cleancode
+
+## X
+
+Replaced instanceof dispatch checks with a strategy pattern in the Waaseyaa API layer. The dispatcher no longer needs to know about every concrete type. https://github.com/waaseyaa/framework/issues/1111 #buildinpublic
+
+## LinkedIn
+
+Refactored the Waaseyaa framework's API dispatch layer to use a strategy pattern instead of a chain of instanceof checks. The dispatch logic no longer needs to know about every concrete request type — each type registers its own handler.
+
+This is the open/closed principle in practice: adding a new request type no longer requires touching the dispatcher. It is one of those refactors that feels obvious after the fact but requires the right moment to justify the change.
+
+https://github.com/waaseyaa/framework/issues/1111


### PR DESCRIPTION
## Summary
- add the April 2026 planning overview in `docs/planning-overview.md`
- add the Week 1 cross-channel calendar in `content-calendar/week-1`
- create milestone #2 and 42 GitHub issues for execution
