### PR TITLE
feat: M1 Spec-Kitty foundation — mining & curation contracts

### DIFF
--- a/.github/workflows/content-mine.yml
+++ b/.github/workflows/content-mine.yml
@@ -12,6 +12,7 @@ on:
         default: '7'
 
 permissions:
+  contents: read
   issues: write
 
 jobs:

--- a/.github/workflows/content-mine.yml
+++ b/.github/workflows/content-mine.yml
@@ -1,0 +1,38 @@
+name: Content Mining
+
+on:
+  schedule:
+    # Daily at 11:00 UTC (7:00 AM ET)
+    - cron: '0 11 * * *'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Number of days to look back'
+        required: false
+        default: '7'
+
+permissions:
+  issues: write
+
+jobs:
+  mine:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout blog repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run git activity mining
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DAYS="${{ github.event.inputs.days || '7' }}"
+          bash scripts/mine-git-activity.sh "$DAYS"

--- a/docs/social/available-for-hire.md
+++ b/docs/social/available-for-hire.md
@@ -1,0 +1,21 @@
+# Available for hire
+
+## Facebook
+
+Updated my GitHub profile with an available for hire section and a lead tracking template. If you are looking for a Go or PHP developer with experience building frameworks, APIs, and AI-integrated systems, I am open to conversations.
+
+https://github.com/jonesrussell/jonesrussell/commit/2e62dbc
+
+#hiring #go #php
+
+## X
+
+Available for hire. Go, PHP, framework dev, AI integration. Updated my profile with details. https://github.com/jonesrussell/jonesrussell/commit/2e62dbc #buildinpublic
+
+## LinkedIn
+
+I have updated my GitHub profile to reflect that I am available for new work. My background is in Go and PHP, with recent focus on framework development (Waaseyaa), AI-integrated systems, and open source tooling.
+
+If you are building something in that space and want to talk, reach out directly or check the profile for context.
+
+https://github.com/jonesrussell/jonesrussell/commit/2e62dbc

--- a/docs/social/giiken-frontend-stack.md
+++ b/docs/social/giiken-frontend-stack.md
@@ -1,0 +1,23 @@
+# Giiken frontend: Vue 3, Vite, Tailwind, Inertia
+
+## Facebook
+
+Scaffolded the Giiken frontend: Vue 3, Vite, Tailwind CSS, and Inertia.js. Standard stack for a Waaseyaa application — the same combination used across the other apps in the ecosystem.
+
+Giiken is a community knowledge management system. The frontend provides the discovery interface where community members search, ask questions, and explore linked documents. Getting the scaffold right means not having to undo decisions later.
+
+https://github.com/waaseyaa/giiken/commit/3895eca
+
+#vue #inertia #buildinpublic
+
+## X
+
+Giiken frontend scaffolded: Vue 3, Vite, Tailwind, Inertia. Discovery interface for community knowledge management, built on Waaseyaa. https://github.com/waaseyaa/giiken/commit/3895eca #buildinpublic
+
+## LinkedIn
+
+Scaffolded the frontend for Giiken, a community knowledge management system built on the Waaseyaa framework. Stack: Vue 3, Vite, Tailwind CSS, and Inertia.js — the same combination used across the Waaseyaa application ecosystem.
+
+The frontend provides the discovery layer: search, semantic Q&A, and document exploration for community members. Using Inertia means keeping the routing and auth in PHP while building the UI in Vue, which fits the Waaseyaa architecture well.
+
+https://github.com/waaseyaa/giiken/commit/3895eca

--- a/docs/social/giiken-product-intro.md
+++ b/docs/social/giiken-product-intro.md
@@ -1,0 +1,25 @@
+# Giiken: community knowledge management on Waaseyaa
+
+## Facebook
+
+Giiken is a community knowledge management system built on the Waaseyaa PHP framework. Here is what has shipped so far: application scaffold, Community and KnowledgeItem entity types, community RBAC policies, a document ingestion pipeline with link and embedding steps, a wiki schema with a lint system, and a query layer with full-text and semantic search.
+
+The MVP acceptance scenario is a real one: a community weighing the Massey Solar project uses Giiken to ingest meeting documents, link related items, and query the knowledge base for prior discussion. The system can surface relevant context that would otherwise be buried in a folder of PDFs.
+
+https://github.com/waaseyaa/giiken
+
+#php #ai #buildinpublic
+
+## X
+
+Giiken MVP: community knowledge management on Waaseyaa. Ingestion pipeline, wiki schema, semantic search, RBAC. Acceptance scenario: the Massey Solar community debate. https://github.com/waaseyaa/giiken #buildinpublic
+
+## LinkedIn
+
+Giiken is a community knowledge management system built on the Waaseyaa PHP framework. The goal is to give communities a way to ingest, link, and query their own documents — meeting records, reports, prior decisions — so that institutional knowledge is searchable rather than buried.
+
+What has shipped: entity types (Community, KnowledgeItem), RBAC policies, a document ingestion pipeline with link and embedding compilation steps, a wiki schema with automated lint checks, and a query layer supporting full-text and semantic search.
+
+The MVP acceptance scenario is grounded in a real case: a community evaluating a solar project uses Giiken to compile and query relevant documents and prior discussion. If the system can surface that context on demand, it works.
+
+https://github.com/waaseyaa/giiken

--- a/docs/social/symfony-floor-constraints.md
+++ b/docs/social/symfony-floor-constraints.md
@@ -1,0 +1,23 @@
+# Symfony ^7.3 floor constraints audit
+
+## Facebook
+
+Audited Symfony version floors across the Waaseyaa framework monorepo. Found 6 packages pinned to ^7.3. Checked each one against its actual Symfony API usage. None of them called anything that requires 7.3. All 6 relaxed to ^7.0.
+
+The policy going forward: every floor constraint needs a named API reason to exist, or it gets relaxed. Undocumented floors are a silent compatibility tax on every downstream consumer.
+
+https://github.com/waaseyaa/framework/issues/1151
+
+#php #symfony #opensource
+
+## X
+
+Audited 6 Symfony ^7.3 floors in our monorepo. None were justified by actual API usage. All 6 relaxed to ^7.0. Policy: every floor needs a named reason or it goes. https://github.com/waaseyaa/framework/issues/1151 #buildinpublic
+
+## LinkedIn
+
+Audited Symfony version floor constraints across the Waaseyaa framework monorepo. Six packages were pinned to ^7.3. After checking each against actual API usage, none of them required anything introduced after 7.0. All six were relaxed.
+
+The new policy: every ^7.x floor constraint must be documented with the specific API or behavior that requires it. If you can't name the reason, you relax it. Undocumented floors silently restrict downstream consumers.
+
+https://github.com/waaseyaa/framework/issues/1151

--- a/docs/social/waaseyaa-boot-to-browser.md
+++ b/docs/social/waaseyaa-boot-to-browser.md
@@ -1,0 +1,23 @@
+# Waaseyaa boot-to-browser DX: 4 framework fixes
+
+## Facebook
+
+Shipped 4 framework fixes targeting the boot-to-browser experience in Waaseyaa: the gap between cloning a repo and having something running in your browser. Each fix removed a step that required manual intervention or produced a confusing error.
+
+This kind of DX work is unsexy but important. A framework that is hard to stand up locally does not get adopted, regardless of what it can do once running.
+
+https://github.com/waaseyaa/framework/issues/1125
+
+#php #dx #waaseyaa
+
+## X
+
+4 Waaseyaa framework fixes targeting the gap between clone and running browser. Boot-to-browser DX matters for adoption. https://github.com/waaseyaa/framework/issues/1125 #buildinpublic
+
+## LinkedIn
+
+Shipped 4 framework-level fixes to the Waaseyaa boot-to-browser experience: the distance between cloning a repository and having the application running in a browser with no manual intervention.
+
+Each fix removed something that required extra steps, produced an unhelpful error, or assumed setup that was not documented. Developer experience at the start of a project shapes whether anyone gets far enough to see what the framework actually does.
+
+https://github.com/waaseyaa/framework/issues/1125

--- a/docs/social/waaseyaa-conformance-governance.md
+++ b/docs/social/waaseyaa-conformance-governance.md
@@ -1,0 +1,25 @@
+# Waaseyaa M11: conformance governance protocols
+
+## Facebook
+
+In an AI-assisted codebase, architectural drift is the default. Each session adds something slightly off-spec. Over time the deviations compound and the architecture you intended is no longer the one you have.
+
+Shipped four governance protocols for the Waaseyaa framework as part of the M11 milestone: a post-execution bootstrap that confirms conformance after each governed change, a canonical governed-change template, a periodic drift-scan for detecting C17+ deviations, and a steady-state conformance loop. Every change goes through the template. The drift scan runs on a schedule. Deviations surface before they compound.
+
+https://github.com/waaseyaa/framework/issues/998
+
+#ai #architecture #buildinpublic
+
+## X
+
+AI-assisted codebases drift by default. Shipped 4 Waaseyaa governance protocols: governed-change template, drift scan, conformance loop, bootstrap. Catch deviations before they compound. https://github.com/waaseyaa/framework/issues/998 #buildinpublic
+
+## LinkedIn
+
+Architectural drift is the default outcome in AI-assisted development. Each session produces something slightly off-spec. Without a systematic check, those deviations accumulate until the codebase no longer reflects the intended architecture.
+
+As part of the Waaseyaa M11 milestone, I shipped four conformance governance protocols: a post-execution bootstrap that confirms architectural conformance after each governed change, a canonical template for governed changes, a periodic drift-scan protocol for detecting deviations at C17 severity and above, and a steady-state conformance loop.
+
+The approach: make governed changes the path of least resistance, make drift visible on a schedule, and catch compounding issues before they require a large remediation effort.
+
+https://github.com/waaseyaa/framework/issues/998

--- a/docs/social/waaseyaa-null-llm-provider.md
+++ b/docs/social/waaseyaa-null-llm-provider.md
@@ -1,0 +1,23 @@
+# Waaseyaa NullLlmProvider for dev and testing
+
+## Facebook
+
+Added a NullLlmProvider to the Waaseyaa AI agent package. It satisfies the LlmProvider interface but does nothing — returns empty responses, logs calls, costs nothing to run.
+
+The point: you should not need a live LLM to run your test suite or spin up a dev environment. Real API calls in tests are slow, flaky, and expensive. The null provider lets you test all the wiring without touching an external service.
+
+https://github.com/waaseyaa/framework/issues/1122
+
+#php #testing #ai
+
+## X
+
+Added NullLlmProvider to Waaseyaa. Satisfies the interface, returns nothing, costs nothing. You should not need a live LLM to run your tests. https://github.com/waaseyaa/framework/issues/1122 #buildinpublic
+
+## LinkedIn
+
+Added a NullLlmProvider to the Waaseyaa framework's AI agent package. It satisfies the LlmProvider interface and returns empty responses — useful for development and testing scenarios where you want to verify the wiring without making real API calls.
+
+The principle is the same as a null mailer or a null payment gateway: your tests should be able to exercise the full stack without depending on external services. Fast, free, and deterministic.
+
+https://github.com/waaseyaa/framework/issues/1122

--- a/docs/social/waaseyaa-nuxt4-upgrade.md
+++ b/docs/social/waaseyaa-nuxt4-upgrade.md
@@ -1,0 +1,23 @@
+# Waaseyaa admin panel: Nuxt 4 upgrade
+
+## Facebook
+
+Upgraded the Waaseyaa admin panel from Nuxt 3 to Nuxt 4. Fixed the proxy architecture while in there, cleaned up the plugin setup. These upgrade sessions are good for catching things that accumulated since the last major bump.
+
+The admin panel is the internal interface for managing a Waaseyaa application — entity types, permissions, content. Keeping it on current Nuxt means staying on the right side of the Vue ecosystem.
+
+https://github.com/waaseyaa/framework/commit/f60a431
+
+#nuxt #vue #waaseyaa
+
+## X
+
+Upgraded the Waaseyaa admin panel to Nuxt 4. Fixed proxy architecture, cleaned up plugins while in there. https://github.com/waaseyaa/framework/commit/f60a431 #buildinpublic
+
+## LinkedIn
+
+Upgraded the Waaseyaa framework's admin panel to Nuxt 4. Along the way, fixed an issue with the proxy architecture and cleaned up the plugin configuration that had accumulated debt since the last major version.
+
+Framework maintenance work like this is not glamorous, but staying current on Nuxt means staying current on Vue 3 patterns, composition API improvements, and the surrounding tooling ecosystem.
+
+https://github.com/waaseyaa/framework/commit/f60a431

--- a/docs/social/waaseyaa-sqlite-dev-mode.md
+++ b/docs/social/waaseyaa-sqlite-dev-mode.md
@@ -1,0 +1,23 @@
+# Waaseyaa serve command: auto-create SQLite in dev mode
+
+## Facebook
+
+Small but useful: the Waaseyaa serve command now auto-creates the SQLite database when running in development mode. One less thing to do when standing up a new app or cloning a fresh repo.
+
+It is the kind of DX friction that adds up — you run the server, it fails, you go find the setup docs, you run a migration manually. Now it just works.
+
+https://github.com/waaseyaa/framework/issues/1116
+
+#php #waaseyaa #dx
+
+## X
+
+Waaseyaa serve command now auto-creates the SQLite database in dev mode. Clone, serve, done. https://github.com/waaseyaa/framework/issues/1116 #buildinpublic
+
+## LinkedIn
+
+A small DX improvement to the Waaseyaa framework: the serve command now automatically creates the SQLite database when running in development mode.
+
+It removes the step where a new developer clones the repo, runs the server, hits a database-not-found error, and has to find the setup instructions. The first run just works.
+
+https://github.com/waaseyaa/framework/issues/1116

--- a/docs/social/waaseyaa-strategy-pattern-dispatch.md
+++ b/docs/social/waaseyaa-strategy-pattern-dispatch.md
@@ -1,0 +1,23 @@
+# Waaseyaa API layer: strategy pattern replaces instanceof dispatch
+
+## Facebook
+
+Replaced a chain of instanceof checks in the Waaseyaa API layer with a strategy pattern. The old code had to know about every concrete type to decide how to handle a request. The new code delegates to the right handler without that knowledge.
+
+The instanceof chain was readable at first. It became a problem every time a new request type was added — you had to touch the dispatch logic, which should not change when you add new types. The strategy pattern fixes that.
+
+https://github.com/waaseyaa/framework/issues/1111
+
+#php #refactoring #cleancode
+
+## X
+
+Replaced instanceof dispatch checks with a strategy pattern in the Waaseyaa API layer. The dispatcher no longer needs to know about every concrete type. https://github.com/waaseyaa/framework/issues/1111 #buildinpublic
+
+## LinkedIn
+
+Refactored the Waaseyaa framework's API dispatch layer to use a strategy pattern instead of a chain of instanceof checks. The dispatch logic no longer needs to know about every concrete request type — each type registers its own handler.
+
+This is the open/closed principle in practice: adding a new request type no longer requires touching the dispatcher. It is one of those refactors that feels obvious after the fact but requires the right moment to justify the change.
+
+https://github.com/waaseyaa/framework/issues/1111

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,45 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "gray-matter": "^4.0.3",
         "playwright": "^1.58.2"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/argparse": {
@@ -49,6 +86,30 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -105,6 +166,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -145,6 +213,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/section-matter": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node schemas/validate.test.js",
+    "validate": "node schemas/validate.js"
   },
   "repository": {
     "type": "git",
@@ -22,6 +23,8 @@
   },
   "homepage": "https://github.com/jonesrussell/blog#readme",
   "devDependencies": {
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "gray-matter": "^4.0.3",
     "playwright": "^1.58.2"
   }

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,60 @@
+# Spec-Kitty: Content Pipeline Schemas
+
+JSON Schema contracts for every artifact in the content pipeline. Each schema validates the output of one pipeline stage and the input of the next.
+
+## Schemas
+
+| Schema | Stage Gate | Validates |
+|---|---|---|
+| `mined-seed.json` | Mine → Curate | Output of mining, input to curation |
+| `curated-item.json` | Curate → Produce | Output of curation, input to production |
+
+Future schemas (M2-M3):
+- `draft.json` — Blog post frontmatter before PR
+- `social-bundle.json` — Social copy package before distribution
+- `distribution-package.json` — Full distribution record
+- `analytics-feedback.json` — Post-distribution performance data
+
+## Validator
+
+Single-file Node.js utility using Ajv.
+
+### CLI usage
+
+```bash
+# Validate a file against a schema
+node schemas/validate.js mined-seed path/to/data.json
+
+# Exit codes: 0 = valid, 1 = invalid, 2 = usage error
+```
+
+### Programmatic usage
+
+```javascript
+const { validate, loadSchema } = require('./validate');
+
+// Validate a file
+const result = validate('mined-seed', '/tmp/seed.json');
+console.log(result.valid);    // true or false
+console.log(result.errors);   // null or array of Ajv errors
+
+// Get a compiled validator function
+const validator = loadSchema('mined-seed');
+const isValid = validator({ source: 'git-commit', ... });
+```
+
+### Running tests
+
+```bash
+npm test
+```
+
+## Where validation happens
+
+- **Claude Code skills:** content-mine and content-curate validate before creating/updating issues
+- **GitHub Actions:** content-mine.yml validates mined seeds before issue creation
+- **CI (M4):** validate-schemas.yml will check artifacts in PRs
+
+## Fixtures
+
+Test fixtures live in `schemas/fixtures/`. Each schema has at least one valid and one invalid fixture used by the test suite.

--- a/schemas/curated-item.json
+++ b/schemas/curated-item.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jonesrussell.github.io/blog/schemas/curated-item.json",
+  "title": "Curated Item",
+  "description": "A content item that has passed human curation in the content pipeline.",
+  "type": "object",
+  "required": [
+    "source", "source_ref", "content_seed", "suggested_type", "suggested_channels", "mined_at",
+    "curated_type", "curated_channels", "curation_action", "curated_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "source": {
+      "type": "string",
+      "enum": ["git-commit", "github-milestone", "design-spec", "blog-post", "north-cloud"]
+    },
+    "source_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "content_seed": {
+      "type": "string",
+      "minLength": 1
+    },
+    "suggested_type": {
+      "type": "string",
+      "enum": ["text-post", "blog-post", "video", "newsletter"]
+    },
+    "suggested_channels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["facebook", "x", "linkedin", "devto", "substack", "youtube"]
+      },
+      "minItems": 1
+    },
+    "mined_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "curated_type": {
+      "type": "string",
+      "enum": ["text-post", "blog-post", "video", "newsletter"],
+      "description": "Human-confirmed content type."
+    },
+    "curated_channels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["facebook", "x", "linkedin", "devto", "substack", "youtube"]
+      },
+      "minItems": 1,
+      "description": "Human-confirmed distribution channels."
+    },
+    "curation_action": {
+      "type": "string",
+      "enum": ["approved", "merged", "edited"],
+      "description": "What the curator decided."
+    },
+    "curated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when curation occurred."
+    },
+    "merge_sources": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Source refs of merged items. Only present when curation_action is 'merged'."
+    },
+    "editorial_notes": {
+      "type": "string",
+      "description": "Human notes on angle, framing, or editorial direction."
+    }
+  }
+}

--- a/schemas/fixtures/invalid-curated-item-missing-action.json
+++ b/schemas/fixtures/invalid-curated-item-missing-action.json
@@ -1,0 +1,11 @@
+{
+  "source": "git-commit",
+  "source_ref": "abc1234",
+  "content_seed": "Some idea",
+  "suggested_type": "text-post",
+  "suggested_channels": ["x"],
+  "mined_at": "2026-04-13T10:00:00Z",
+  "curated_type": "text-post",
+  "curated_channels": ["x"],
+  "curated_at": "2026-04-13T11:30:00Z"
+}

--- a/schemas/fixtures/invalid-mined-seed-bad-enum.json
+++ b/schemas/fixtures/invalid-mined-seed-bad-enum.json
@@ -1,0 +1,8 @@
+{
+  "source": "slack-message",
+  "source_ref": "abc1234",
+  "content_seed": "Some idea",
+  "suggested_type": "text-post",
+  "suggested_channels": ["x"],
+  "mined_at": "2026-04-13T10:00:00Z"
+}

--- a/schemas/fixtures/invalid-mined-seed-missing-source.json
+++ b/schemas/fixtures/invalid-mined-seed-missing-source.json
@@ -1,0 +1,7 @@
+{
+  "source_ref": "abc1234",
+  "content_seed": "Some idea",
+  "suggested_type": "text-post",
+  "suggested_channels": ["x"],
+  "mined_at": "2026-04-13T10:00:00Z"
+}

--- a/schemas/fixtures/valid-curated-item.json
+++ b/schemas/fixtures/valid-curated-item.json
@@ -1,0 +1,13 @@
+{
+  "source": "git-commit",
+  "source_ref": "abc1234",
+  "content_seed": "Added SovereigntyProfile to Layer 0. Communities declare local/hybrid/cloud sovereignty mode.",
+  "suggested_type": "text-post",
+  "suggested_channels": ["x", "linkedin", "facebook"],
+  "mined_at": "2026-04-13T10:00:00Z",
+  "confidence": 0.85,
+  "curated_type": "text-post",
+  "curated_channels": ["x", "linkedin"],
+  "curation_action": "approved",
+  "curated_at": "2026-04-13T11:30:00Z"
+}

--- a/schemas/fixtures/valid-mined-seed.json
+++ b/schemas/fixtures/valid-mined-seed.json
@@ -1,0 +1,9 @@
+{
+  "source": "git-commit",
+  "source_ref": "abc1234",
+  "content_seed": "Added SovereigntyProfile to Layer 0. Communities declare local/hybrid/cloud sovereignty mode.",
+  "suggested_type": "text-post",
+  "suggested_channels": ["x", "linkedin", "facebook"],
+  "mined_at": "2026-04-13T10:00:00Z",
+  "confidence": 0.85
+}

--- a/schemas/mined-seed.json
+++ b/schemas/mined-seed.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jonesrussell.github.io/blog/schemas/mined-seed.json",
+  "title": "Mined Seed",
+  "description": "A content seed produced by the mining stage of the content pipeline.",
+  "type": "object",
+  "required": ["source", "source_ref", "content_seed", "suggested_type", "suggested_channels", "mined_at"],
+  "additionalProperties": false,
+  "properties": {
+    "source": {
+      "type": "string",
+      "enum": ["git-commit", "github-milestone", "design-spec", "blog-post", "north-cloud"],
+      "description": "Where the seed came from."
+    },
+    "source_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Commit SHA, issue URL, file path, or North Cloud article ID."
+    },
+    "content_seed": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The raw idea or excerpt."
+    },
+    "suggested_type": {
+      "type": "string",
+      "enum": ["text-post", "blog-post", "video", "newsletter"],
+      "description": "Recommended content type."
+    },
+    "suggested_channels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["facebook", "x", "linkedin", "devto", "substack", "youtube"]
+      },
+      "minItems": 1,
+      "description": "Recommended distribution channels."
+    },
+    "mined_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when mining occurred."
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Signal strength (0-1). Optional."
+    }
+  }
+}

--- a/schemas/validate.js
+++ b/schemas/validate.js
@@ -1,0 +1,50 @@
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+const fs = require('fs');
+const path = require('path');
+
+const SCHEMAS_DIR = __dirname;
+
+function loadSchema(name) {
+  const schemaPath = path.join(SCHEMAS_DIR, `${name}.json`);
+  if (!fs.existsSync(schemaPath)) {
+    throw new Error(`Schema not found: ${schemaPath}`);
+  }
+  const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+  const ajv = new Ajv({ allErrors: true });
+  addFormats(ajv);
+  return ajv.compile(schema);
+}
+
+function validate(schemaName, filePath) {
+  const validator = loadSchema(schemaName);
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const valid = validator(data);
+  return {
+    valid,
+    errors: valid ? null : validator.errors
+  };
+}
+
+// CLI mode: node schemas/validate.js <schema-name> <file-path>
+if (require.main === module) {
+  const [schemaName, filePath] = process.argv.slice(2);
+  if (!schemaName || !filePath) {
+    console.error('Usage: node schemas/validate.js <schema-name> <file-path>');
+    console.error('Example: node schemas/validate.js mined-seed data.json');
+    process.exit(2);
+  }
+  const result = validate(schemaName, filePath);
+  if (result.valid) {
+    console.log(`✓ ${filePath} is valid against ${schemaName}`);
+    process.exit(0);
+  } else {
+    console.error(`✗ ${filePath} failed validation against ${schemaName}:`);
+    result.errors.forEach(err => {
+      console.error(`  - ${err.instancePath || '(root)'}: ${err.message}`);
+    });
+    process.exit(1);
+  }
+}
+
+module.exports = { validate, loadSchema };

--- a/schemas/validate.test.js
+++ b/schemas/validate.test.js
@@ -41,6 +41,21 @@ console.log('validate bad enum value');
 const badEnumResult = validate('mined-seed', path.join(__dirname, 'fixtures/invalid-mined-seed-bad-enum.json'));
 assert(badEnumResult.valid === false, 'bad enum value fails validation');
 
+// Test: curated-item schema loads
+console.log('loadSchema curated-item');
+const curatedValidator = loadSchema('curated-item');
+assert(typeof curatedValidator === 'function', 'returns a function for curated-item schema');
+
+// Test: validate valid curated item
+console.log('validate valid curated item');
+const validCurated = validate('curated-item', path.join(__dirname, 'fixtures/valid-curated-item.json'));
+assert(validCurated.valid === true, 'valid curated item passes');
+
+// Test: validate missing curation_action
+console.log('validate missing curation_action');
+const missingAction = validate('curated-item', path.join(__dirname, 'fixtures/invalid-curated-item-missing-action.json'));
+assert(missingAction.valid === false, 'missing curation_action fails validation');
+
 // Summary
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/schemas/validate.test.js
+++ b/schemas/validate.test.js
@@ -1,0 +1,46 @@
+const { validate, loadSchema } = require('./validate');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    passed++;
+    console.log(`  ✓ ${message}`);
+  } else {
+    failed++;
+    console.error(`  ✗ ${message}`);
+  }
+}
+
+// Test: loadSchema returns a compiled validator
+console.log('loadSchema');
+const validator = loadSchema('mined-seed');
+assert(typeof validator === 'function', 'returns a function for a known schema');
+
+let threw = false;
+try { loadSchema('nonexistent-schema'); } catch (e) { threw = true; }
+assert(threw, 'throws for unknown schema name');
+
+// Test: validate with valid fixture
+console.log('validate valid fixture');
+const validResult = validate('mined-seed', path.join(__dirname, 'fixtures/valid-mined-seed.json'));
+assert(validResult.valid === true, 'valid fixture passes');
+assert(validResult.errors === null, 'no errors on valid fixture');
+
+// Test: validate with missing required field
+console.log('validate missing required field');
+const missingResult = validate('mined-seed', path.join(__dirname, 'fixtures/invalid-mined-seed-missing-source.json'));
+assert(missingResult.valid === false, 'missing source fails validation');
+assert(Array.isArray(missingResult.errors), 'returns errors array');
+assert(missingResult.errors.length > 0, 'errors array is not empty');
+
+// Test: validate with bad enum value
+console.log('validate bad enum value');
+const badEnumResult = validate('mined-seed', path.join(__dirname, 'fixtures/invalid-mined-seed-bad-enum.json'));
+assert(badEnumResult.valid === false, 'bad enum value fails validation');
+
+// Summary
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/mine-git-activity.sh
+++ b/scripts/mine-git-activity.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mine-git-activity.sh
+# Scans configured repos for recent git activity and creates content queue issues.
+# Called by .github/workflows/content-mine.yml
+#
+# Usage: ./scripts/mine-git-activity.sh [days]
+# Default: 7 days lookback
+
+DAYS="${1:-7}"
+SINCE_DATE=$(date -u -d "${DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-${DAYS}d +%Y-%m-%dT%H:%M:%SZ)
+QUEUE_REPO="jonesrussell/jonesrussell"
+VALIDATOR="node $(dirname "$0")/../schemas/validate.js"
+REPOS=("waaseyaa/framework" "waaseyaa/giiken" "jonesrussell/blog" "jonesrussell/jonesrussell")
+
+MINED_COUNT=0
+SKIPPED_COUNT=0
+
+echo "Mining git activity since ${SINCE_DATE} (${DAYS} days)"
+
+# Fetch existing queue issue titles to avoid duplicates
+EXISTING_TITLES=$(gh issue list --repo "$QUEUE_REPO" --label "content-queue" --json title --jq '.[].title' --limit 100)
+
+for repo in "${REPOS[@]}"; do
+  echo "--- Scanning ${repo} ---"
+
+  # Fetch recent commits
+  COMMITS=$(gh api "repos/${repo}/commits?since=${SINCE_DATE}&per_page=50" \
+    --jq '.[] | select(.commit.message | test("^(Merge |bump |chore\\(deps\\)|ci:|fix typo|formatting)"; "i") | not) | {sha: .sha[0:7], message: .commit.message, date: .commit.author.date}' \
+    2>/dev/null || echo "")
+
+  if [[ -z "$COMMITS" ]]; then
+    echo "  No qualifying commits found."
+    continue
+  fi
+
+  echo "$COMMITS" | jq -c '.' | while read -r commit_json; do
+    SHA=$(echo "$commit_json" | jq -r '.sha')
+    MESSAGE=$(echo "$commit_json" | jq -r '.message' | head -1)
+    COMMIT_DATE=$(echo "$commit_json" | jq -r '.date')
+
+    # Skip short messages (likely trivial)
+    if [[ ${#MESSAGE} -lt 10 ]]; then
+      SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+      continue
+    fi
+
+    # Skip if already in queue
+    if echo "$EXISTING_TITLES" | grep -qF "$MESSAGE"; then
+      echo "  Skipping (already queued): ${MESSAGE}"
+      continue
+    fi
+
+    # Build seed JSON
+    SEED_FILE=$(mktemp /tmp/mined-seed-XXXXXX.json)
+    cat > "$SEED_FILE" << SEED
+{
+  "source": "git-commit",
+  "source_ref": "https://github.com/${repo}/commit/${SHA}",
+  "content_seed": $(echo "$MESSAGE" | jq -Rs .),
+  "suggested_type": "text-post",
+  "suggested_channels": ["x", "linkedin", "facebook"],
+  "mined_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+SEED
+
+    # Validate against schema
+    if $VALIDATOR mined-seed "$SEED_FILE" > /dev/null 2>&1; then
+      # Create the queue issue
+      ISSUE_BODY="## Source\n\n**Repo:** ${repo}\n**Commit:** ${SHA}\n**Date:** ${COMMIT_DATE}\n\n## Content Seed\n\n${MESSAGE}\n\n## Suggested\n\n- **Type:** text-post\n- **Channels:** x, linkedin, facebook"
+
+      gh issue create --repo "$QUEUE_REPO" \
+        --title "[content] ${MESSAGE}" \
+        --label "content-queue,stage:mined,type:text-post" \
+        --body "$(echo -e "$ISSUE_BODY")" \
+        > /dev/null
+
+      echo "  ✓ Mined: ${MESSAGE}"
+      MINED_COUNT=$((MINED_COUNT + 1))
+    else
+      echo "  ✗ Validation failed for commit ${SHA}, skipping"
+      $VALIDATOR mined-seed "$SEED_FILE" 2>&1 || true
+    fi
+
+    rm -f "$SEED_FILE"
+  done
+done
+
+echo ""
+echo "Mining complete: ${MINED_COUNT} issues created, ${SKIPPED_COUNT} skipped"

--- a/scripts/mine-git-activity.sh
+++ b/scripts/mine-git-activity.sh
@@ -35,7 +35,7 @@ for repo in "${REPOS[@]}"; do
     continue
   fi
 
-  echo "$COMMITS" | jq -c '.' | while read -r commit_json; do
+  while read -r commit_json; do
     SHA=$(echo "$commit_json" | jq -r '.sha')
     MESSAGE=$(echo "$commit_json" | jq -r '.message' | head -1)
     COMMIT_DATE=$(echo "$commit_json" | jq -r '.date')
@@ -84,7 +84,7 @@ SEED
     fi
 
     rm -f "$SEED_FILE"
-  done
+  done < <(echo "$COMMITS" | jq -c '.')
 done
 
 echo ""


### PR DESCRIPTION
## Summary

- Introduces Spec-Kitty, a JSON Schema contract layer for the content pipeline (Mine → Curate → Produce → Distribute → Monitor)
- Adds `mined-seed.json` and `curated-item.json` schemas with Ajv-based validator utility (11/11 tests passing)
- Adds scheduled content mining GitHub Action (daily cron + manual dispatch) with `scripts/mine-git-activity.sh`
- Retrofits `content-mine` and `content-curate` Claude Code skills with schema validation gates

## What's in this PR

| Category | Files |
|---|---|
| Schemas | `schemas/mined-seed.json`, `schemas/curated-item.json` |
| Validator | `schemas/validate.js`, `schemas/validate.test.js` |
| Fixtures | `schemas/fixtures/` (5 test fixtures) |
| Automation | `.github/workflows/content-mine.yml`, `scripts/mine-git-activity.sh` |
| Docs | `schemas/README.md` |

## Spec

Design spec: `docs/superpowers/specs/2026-04-13-content-pipeline-refactor-design.md`
Implementation plan: `docs/superpowers/plans/2026-04-13-m1-foundation-mining-curation-contracts.md`

This is M1 of 4 milestones. M2 (Production: Writing & Social Contracts) follows after this stabilizes.

## Test plan

- [ ] `npm test` passes (11/11 schema validation tests)
- [ ] `node schemas/validate.js mined-seed schemas/fixtures/valid-mined-seed.json` exits 0
- [ ] `node schemas/validate.js mined-seed schemas/fixtures/invalid-mined-seed-missing-source.json` exits 1
- [ ] Hugo build succeeds (`task build`)
- [ ] Content mining workflow appears in Actions tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)